### PR TITLE
Implement commands for configuration of filters

### DIFF
--- a/lib/git-media.rb
+++ b/lib/git-media.rb
@@ -129,22 +129,32 @@ module GitMedia
           GitMedia::Sync.run! :download_only => true
         when 'status'
           require 'git-media/status'
+          require 'git-media/config'
           Trollop::options do
             opt :force, "Force status"
           end
           GitMedia::Status.run!
-		when 'list'
-		  require 'git-media/list'
-		  GitMedia::List.run!
+          GitMedia::Config.run!(:status)
+		    when 'list'
+		      require 'git-media/list'
+		      GitMedia::List.run!
+        when 'install'
+          require 'git-media/config'
+          GitMedia::Config.run!(:install)
+        when 'uninstall'
+          require 'git-media/config'
+          GitMedia::Config.run!(:uninstall)
         else
-	  print <<EOF
+	       print <<EOF
 usage: git media sync|download|status|list|clear
   
-  sync     Sync files with remote server
-  download Download files that are missing; don't upload any files
-  status   Show files that are waiting to be uploaded and file size
-  list     List local cache and corresponding media file
-  clear    Upload and delete the local cache of media files
+  sync      Sync files with remote server
+  download  Download files that are missing; don't upload any files
+  status    Show files that are waiting to be uploaded and file size
+  list      List local cache and corresponding media file
+  clear     Upload and delete the local cache of media files
+  install   Set up the attributes filter settings in git config  
+  uninstall Removes the attributes filter settings in git config  
 EOF
         end
 

--- a/lib/git-media/config.rb
+++ b/lib/git-media/config.rb
@@ -1,0 +1,71 @@
+require 'git-media/helpers/git_ops'
+
+module GitMedia
+  module Config
+
+    extend Helpers::GitOps
+
+    def self.run!(action)
+      return uninstall_settings if action == :uninstall
+      return install_settings if action == :install
+      return print_status if action == :status
+      throw "Unknown action #{action}"
+    end    
+
+    def self.print_status
+        if are_settings_installed? 
+          puts("Filters are already installed")
+        else
+          puts("No filters found in configuration")
+        end
+    end
+
+    def self.are_settings_installed?
+      clean_filter_value = get_git_config(filter_clean_key)
+      smudge_filter_value = get_git_config(filter_smudge_key)
+
+      return !(clean_filter_value.empty? || smudge_filter_value.empty?) &&
+            filter_clean_cmd.include?(clean_filter_value) &&
+            filter_smudge_cmd.include?(smudge_filter_value)
+    end
+
+    def self.install_settings
+      return print_status if are_settings_installed? 
+
+      set_git_config(filter_clean_key, filter_clean_cmd)
+      set_git_config(filter_smudge_key, filter_smudge_cmd)
+
+      puts "Clean & smudge filters have been installed in the local repository configuration (.git/config)"
+      puts "Remember to configure the transport for git-media to work correctly"
+    end
+
+    def self.uninstall_settings
+      return print_status unless are_settings_installed? 
+
+      git_config(filter_key, :remove_section)
+
+      puts "Clean & smudge filters have been removed from the local repository git configuration"
+    end
+
+    private
+    def self.filter_clean_key
+      "filter.media.clean"
+    end
+
+    def self.filter_smudge_key
+      "filter.media.smudge"
+    end
+
+    def self.filter_key
+      "filter.media"
+    end 
+
+    def self.filter_clean_cmd
+      "\"git-media filter-clean\""
+    end
+
+    def self.filter_smudge_cmd
+      "\"git-media filter-smudge\""
+    end
+  end
+end

--- a/lib/git-media/helpers/git_ops.rb
+++ b/lib/git-media/helpers/git_ops.rb
@@ -1,0 +1,22 @@
+module GitMedia
+  module Helpers
+    module GitOps
+
+      def git_config(key, action, value=nil)
+        action = "--#{action.to_s.gsub('_', '-')}" unless action.nil?
+
+        cmd = "git config --local #{action} #{key} #{value}"
+        `#{cmd}`
+      end
+
+      def get_git_config(key)
+        git_config(key, :get).strip
+      end
+
+      def set_git_config(key, value)
+        git_config(key, nil, value)
+      end
+
+    end
+  end
+end

--- a/lib/git-media/status.rb
+++ b/lib/git-media/status.rb
@@ -14,7 +14,7 @@ module GitMedia
     # find tree entries that are likely media references
     def self.find_references
       references = {:to_expand => [], :expanded => [], :deleted => []}
-      files = `git ls-tree -lz -r HEAD | tr "\\000" \\\\n`.split("\n")
+      files = `git ls-tree -l -r HEAD`.split("\n")
       files = files.map { |f| s = f.split("\t"); [s[0].split(' ').last, s[1]] }
       files = files.select { |f| f[0] == '41' } # it's the right size
       files.each do |tree_size, fname|

--- a/spec/media_spec.rb
+++ b/spec/media_spec.rb
@@ -7,7 +7,7 @@ require 'spec_helper'
 describe "Media" do
     
   it "should clean and smudge and save data in buffer area" do
-    in_temp_git_w_media do
+    in_temp_git_repository_with_media_filters do |tmp_path|
       git('add .')
       git("commit -m 'testing'")
       
@@ -38,4 +38,18 @@ describe "Media" do
   
   it "should sync with a local transport"
   
+  it "should add/remove the filters to the config file" do
+    
+    in_temp_git_repository do |tmp_path|
+      `git media install`
+      get_git_config("filter.media.clean").should include("git-media filter-clean")
+      get_git_config("filter.media.smudge").should include("git-media filter-smudge")
+
+      `git media uninstall`
+      get_git_config("filter.media.clean").should_not include("git-media filter-clean")
+      get_git_config("filter.media.smudge").should_not include("git-media filter-smudge")
+
+    end
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,31 +5,34 @@ require 'pp'
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'git-media'
+require 'git-media/helpers/git_ops'
 
 RSpec.configure do |config|
 end
 
-def in_temp_git
+include GitMedia::Helpers::GitOps
+
+def in_temp_git_repository
   tf = Tempfile.new('gitdir')
   temppath = tf.path
   tf.unlink
   FileUtils.mkdir(temppath)
-  Dir.chdir(temppath) do
+  Dir.chdir(temppath) do 
     `git init`
-    yield
+    yield temppath
   end
 end
 
-def in_temp_git_w_media
+def in_temp_git_repository_with_media_filters
   bin = File.join(File.dirname(__FILE__), '..', 'bin', 'git-media')  
-  in_temp_git do
+  in_temp_git_repository do |tmp_path|
     append_file('testing1.x22', '1234567')
     append_file('testing2.x22', '123456789')
     append_file('normal.txt', 'hello world')
     append_file('.gitattributes', '*.x22 filter=media -crlf')
     `git config filter.media.clean "#{bin} filter-clean"`
     `git config filter.media.smudge "#{bin} filter-smudge"`
-    yield
+    yield tmp_path
   end
 end
 


### PR DESCRIPTION
Two new commands: git media install, git media uninstall.
The commands installs or uninstall the clear and smudge filters.
This automates the git media  operations so they are performed automatically
when using git in a normal workflow.

Filters are put in the local repository config file (.git/config)
